### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Tag](https://img.shields.io/github/tag/cytopia/linux-timemachine.svg)](https://github.com/cytopia/linux-timemachine/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-This shell script mimics the behavior of OSX's timemachine. It uses [rsync](https://linux.die.net/man/1/rsync) to incrementally backup your data to a different directory or hard disk. All operations are incremental, atomic and automatically resumable.
+This shell script mimics the behavior of OSX's timemachine. It uses [rsync](https://linux.die.net/man/1/rsync) to incrementally back up your data to a different directory or hard disk. All operations are incremental, atomic and automatically resumable.
 
-By default the only rsync option used is `--recursive`. This is due to the fact that some remote NAS implementations do not support symlinks, changing owner, group or permissions (due to restrictive ACL's). If you want to use any other rsync arguments, you can simply append them.
+By default the only rsync option used is `--recursive`. This is because some remote NAS implementations do not support symlinks, changing owner, group or permissions (due to restrictive ACL's). If you want to use any other rsync arguments, you can simply append them.
 
 ## TL;DR
 
@@ -37,19 +37,19 @@ $ timemachine --verbose /source/dir /target/dir -- --verbose
 
 Backups are always done incrementally using rsync's ability to hardlink to previous backup directories. You can nevertheless always see the full backup on the file system of any incrementally made backup without having to generate it. This will also be true when deleting any of the previously created backup directories. See the [Backups](#backups) section for how this is achieved via rsync.
 
-Incremental Backups also mean that only the changes on your source, compared to what is already on the target have to be backed up. This will safe you time as well as disk space on the target disk.
+Incremental Backups also mean that only the changes on your source, compared to what is already on the target, have to be backed up. This will save you time as well as disk space on the target disk.
 
 #### Partial
 
-When backing up, files are transmitted partially so in case a 2GB movie file backup is interrupted, the next run will pick up exactly where it left off at that file and will not start to copy it from scratch.
+When backing up, files are transmitted partially, so in case a 2GB movie file backup is interrupted the next run will pick up exactly where it left off at that file and will not start to copy it from scratch.
 
 #### Resumable
 
-Not only is this script keeping partial files, but the whole backup run is also resumable. Whenever there is an unfinished backup and you start `timemachine` again, it will automatically resume it. It will resume any previously failed backup as long as it finally succeeds.
+Not only is this script keeping partial files, but also the whole backup run is also resumable. Whenever there is an unfinished backup and you start `timemachine` again, it will automatically resume it. It will resume any previously failed backup as long as it finally succeeds.
 
 #### Atomic
 
-The whole backup procedure is atomic. Only if and when the backup procedure succeeds, it is also properly named and symlinked. Any non-successful backup directory is either waiting to be resumed or to be deleted.
+The whole backup procedure is atomic. Only if and when the backup procedure succeeds, it is then properly named and symlinked. Any non-successful backup directory is either waiting to be resumed or to be deleted.
 
 ## Backups
 
@@ -67,7 +67,7 @@ lrwxrwxrwx 1   20 Jan  6 18:50 current -> 2018-01-06__18-50-52/
 All backups are incremental except the first created one.
 You can nevertheless safely remove all previous folders and the remaining folders will still have all of their content.
 
-Backups are done incrementally, so least space is consumed. Due to `rsync`'s ability, every folder will still contain all files, even though they are just incremental backups. This is archived via hardlinks.
+Backups are done incrementally, so the least amount of space is consumed. Due to `rsync`'s ability, every folder will still contain all files, even though they are just incremental backups. This is archived via hardlinks.
 ```
 $ du -hd1 .
 497M    ./2018-01-06__18-43-30
@@ -77,7 +77,7 @@ $ du -hd1 .
 497M    .
 ```
 
-You can also safely delete the full backup folder without having to worry to loose any of your full backup data:
+You can also safely delete the full backup folder without having to worry about losing any of your full backup data:
 ```
 $ rm -rf ./2018-01-06__18-43-30
 $ du -hd1 .
@@ -92,7 +92,7 @@ $ du -hd1 .
 
 ## Failures
 
-In case the `timemachine` script aborts (self-triggered, disk unavailable or any other reason) you can simply run it again and it will automatically resume the last failed run.
+In case the `timemachine` script aborts (self-triggered, disk unavailable or any other reason) you can simply run it again to automatically resume the last failed run.
 
 There will be a directory `.inprogress/` in your specified destination. This will hold all already transferred data and will be picked up during the next run.
 
@@ -106,14 +106,14 @@ Usage: timemachine [-v] <source> <destination> -- [rsync opts]
        timemachine -h
 
 This shell script mimics the behavior of OSX's timemachine.
-It uses rsync to incrementally backup your data to a different directory.
+It uses rsync to incrementally back up your data to a different directory.
 All operations are incremental, atomic and automatically resumable.
 
 By default the only rsync option used is --recursive.
-This is due to the fact that some remote NAS implementations do not support
-symlinks, changing owner, group or permissions (due to restrictive ACL's).
-If you want to use any of those options you can simply append them.
-See Example section for how to.
+This is because some remote NAS implementations do not support
+symlinks, changing owner, group or permissions (due to restrictive ACLs).
+If you want to use any of those options, you can simply append them.
+See the Example section for how to.
 
 Required arguments:
   <source>        Source directory
@@ -127,7 +127,7 @@ Misc Options:
   -h, --help      Show this help screen
 
 Examples:
-  Simply backup one directory recursively
+  Simply back up one directory recursively
       timemachine /home/user /data
   Do the same, but be verbose
       timemachine -v /home/user /data


### PR DESCRIPTION
 - 'back up' (the compound verb) and 'backup' (the conjoined noun) are spelled differently.
 - commas delineate both ends of a subordinate clause
 - spelling 
 - 'not only' always attracts a 'but also'
 - we never pluralize with an apostrophe.  If you find yourself wanting to use one, look for the actual error.