### PR TITLE
Release v1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## Release v1.2
+
+#### Fixed
+- Fixed `identityity` typo to `identity` in option parsing loop.
+
+
 ## Release v1.1
 
 #### Added

--- a/timemachine
+++ b/timemachine
@@ -243,7 +243,7 @@ while getopts :vdpi:hV-: opt; do
 			PORT="${1}"
 			SSH_ARGS="${SSH_ARGS} -p ${PORT}"
 			;;
-		i | identityity)
+		i | identity)
 			shift
 			KEY="${1}"
 			SSH_ARGS="${SSH_ARGS} -i ${KEY}"


### PR DESCRIPTION
## Release v1.2

#### Fixed
- Fixed `identityity` typo to `identity` in option parsing loop.
