### PR TITLE
Release v1.3

### DIFF
--- a/timemachine
+++ b/timemachine
@@ -13,8 +13,8 @@ MY_DESC="OSX-like timemachine cli script for Linux and BSD (and even OSX)"
 MY_PROJ="https://github.com/cytopia/linux-timemachine"
 MY_AUTH="cytopia"
 MY_MAIL="cytopia@everythingcli.org"
-MY_VERS="1.1"
-MY_DATE="2021-01-30"
+MY_VERS="1.3"
+MY_DATE="2021-04-08"
 
 # Default command line arguments
 VERBOSE=

--- a/timemachine
+++ b/timemachine
@@ -1,6 +1,7 @@
 #!/bin/sh -eu
 #
 # https://serverfault.com/questions/834994/rsync-only-keep-10-backup-folders
+export PATH=/bin:/usr/bin
 
 ################################################################################
 # Variables


### PR DESCRIPTION
# Release v1.3

Ensure that `$PATH` variable is explicitly set, so that you can't overwrite it from outside.

* **See here for initial finding:** https://github.com/cytopia/linux-timemachine/pull/65

#### Without setting
The exported $PATH will only be valid/scoped within the script itself and will not effect the outside environment. So with this set, I've tried the path manipulation again:
```bash
$ PATH= ./timemachine
2021-04-01 12:26:35 timemachine: [ERROR] <source> and <destination> are required. See -h for help.
```

So this looks like it is fixing the issue of overriding the path from outside.

**Note:** In the above `export PATH` example, I've not specified any `sbin/` directories, as they're not required for this script. So overall that should be pretty save, as a user won't be able to write to those directories
