### PR TITLE
Support passing multiple arguments

### DIFF
--- a/timemachine
+++ b/timemachine
@@ -221,7 +221,7 @@ link_directory() {
 ################################################################################
 
 # Parse input args with getopts
-while getopts :vdpi:hV-: opt; do
+while getopts :vdp:i:hV-: opt; do
 	# ----- long options
 	if [ "${opt}" = "-" ]; then
 		opt=${OPTARG}
@@ -240,13 +240,11 @@ while getopts :vdpi:hV-: opt; do
 			;;
 		# ----- Options
 		p | port)
-			shift
-			PORT="${1}"
+			PORT="${OPTARG}"
 			SSH_ARGS="${SSH_ARGS} -p ${PORT}"
 			;;
 		i | identity)
-			shift
-			KEY="${1}"
+			KEY="${OPTARG}"
 			SSH_ARGS="${SSH_ARGS} -i ${KEY}"
 			;;
 		v | verbose)
@@ -264,10 +262,9 @@ while getopts :vdpi:hV-: opt; do
 			exit 2
 			;;
 	esac
-	shift
 done
 
-
+shift $((OPTIND-1))
 
 ################################################################################
 # Entrypoint: Validate cmd args


### PR DESCRIPTION
Hey! Thanks for this awesome tool :D 

I noticed while trying to run it both with `--debug` and a custom port (`-p 2222`) that it wouldn't behave as expected, e.g.:

```sh
mkdir a b
./timemachine -d -p 2222 a/ b/
2021-10-13 08:45:20 timemachine: [DEBUG] test -d '-p'
2021-10-13 08:45:20 timemachine: [ERROR] Source directory does not exist: '-p'. See -h for help.
```

This is because of using `shift` *inside* the `getopts` loop. It appears that `getopts` gets confused by this because it keeps track of the arguments count in `OPTIND` and doesn't expect the arguments to be shifted during the loop. This results in skipping one argument from `getopts` perspective every `shift` so it ends before having processed all options.

To fix this, I modified the `getopts` string to include a `:` after `p` so that it effectively expects the `-p` option to take an argument, which is going to be set in `OPTARG`. We can then use this `OPTARG` for both `-p` and `-i` instead of shifting, and do a final shift after the loop using `shift $((OPTIND-1))` which effectively shifts all options processed by `getopts`.

Cheers! 