### PR TITLE
Fixed [*.sh] syntax in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
-[.sh}]
+[*.sh]
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
This PR fixes the `[*.sh]` syntax in `.editorconfig` by adding an `*` and removing a `}`