### PR TITLE
Honor .rsync-filter files

### DIFF
--- a/timemachine
+++ b/timemachine
@@ -439,6 +439,7 @@ if link_exists "${DEST}/${BACKUP_LATEST}"; then
 		--links \
 		--delete \
 		--delete-excluded \
+		--filter='dir-merge /.rsync-filter' \
 		--partial-dir=${RSYNC_PARTIAL} \
 		--link-dest=../${BACKUP_LATEST} \
 		$* \
@@ -460,6 +461,7 @@ else
 		--delete \
 		--delete-excluded \
 		--partial-dir=${RSYNC_PARTIAL} \
+		--filter='dir-merge /.rsync-filter' \
 		$* \
 		$( escape_path "${SRC}" ) $( escape_path "${DEST}/${BACKUP_INPROGRESS}" )"
 fi


### PR DESCRIPTION
Auto-add `--filter='dir-merge /.rsync-filter'` (which is also available with `-F`) so users don't have to go out of their way to manually add that option:

```
       -F     The -F option is a shorthand for adding two --filter rules to your command.  The first time it is used is a shorthand for this rule:

                  --filter='dir-merge /.rsync-filter'

              This tells rsync to look for per-directory .rsync-filter files that have been sprinkled through the hierarchy and use their rules to filter the files in the transfer. 
```

This in turn makes it easier for users to exclude problematic files (#71) simply by adding a file with `- problem_file`.

See also #64 and #84 for where this would be useful.